### PR TITLE
Change separator symbol from "_" to "-"

### DIFF
--- a/NUGET.md
+++ b/NUGET.md
@@ -79,7 +79,7 @@ DB table for each memory index.
 
 Table names have a configurable **prefix**, used to filter out other tables that
 might be present. The prefix is mandatory, cannot be empty, we suggest using
-the default `km_` prefix.
+the default `km-` prefix.
 
 Overall we recommend not mixing external tables in the same DB used for
 Kernel Memory.

--- a/PostgresMemoryStorage/Db/PostgresSchema.cs
+++ b/PostgresMemoryStorage/Db/PostgresSchema.cs
@@ -8,7 +8,7 @@ internal static class PostgresSchema
 {
     public const string PlaceholdersTags = "{{$tags}}";
 
-    private static readonly Regex s_validNameRegex = new(@"^[a-zA-Z0-9_]+$");
+    private static readonly Regex s_validNameRegex = new(@"^[a-zA-Z0-9\-]+$");
 
     public static void ValidateSchemaName(string name)
     {

--- a/PostgresMemoryStorage/PostgresConfig.cs
+++ b/PostgresMemoryStorage/PostgresConfig.cs
@@ -44,7 +44,7 @@ public class PostgresConfig
     /// <summary>
     /// Default prefix used for table names
     /// </summary>
-    public const string DefaultTableNamePrefix = "km_";
+    public const string DefaultTableNamePrefix = "km-";
 
     /// <summary>
     /// Connection string required to connect to Postgres
@@ -60,7 +60,7 @@ public class PostgresConfig
     /// Mandatory prefix to add to tables created by KM.
     /// This is used to distinguish KM tables from others in the same schema.
     /// </summary>
-    /// <remarks>Default value is set to "km_" but can be override when creating a config.</remarks>
+    /// <remarks>Default value is set to "km-" but can be override when creating a config.</remarks>
     public string TableNamePrefix { get; set; } = DefaultTableNamePrefix;
 
     /// <summary>

--- a/README.md
+++ b/README.md
@@ -103,7 +103,9 @@ DB table for each memory index.
 
 Table names have a configurable **prefix**, used to filter out other tables that
 might be present. The prefix is mandatory, cannot be empty, we suggest using
-the default `km_` prefix.
+the default `km-` prefix. Note that the Postgres connector automatically converts
+`_` underscores to `-` dashes to have a consistent behavior with other storage
+types supported by Kernel Memory.
 
 Overall we recommend not mixing external tables in the same DB used for
 Kernel Memory.

--- a/nuget-package.props
+++ b/nuget-package.props
@@ -1,7 +1,7 @@
 ﻿<Project>
     <PropertyGroup>
         <!-- Central version prefix - applies to all nuget packages. -->
-        <Version>0.2.0</Version>
+        <Version>0.3.0</Version>
 
         <!-- Default description and tags. Packages can override. -->
         <Authors>Microsoft</Authors>

--- a/tests/FunctionalTests/ConcurrencyTests.cs
+++ b/tests/FunctionalTests/ConcurrencyTests.cs
@@ -93,8 +93,8 @@ public class ConcurrencyTests : BaseTestCase
     public async Task UpsertConcurrencyTest()
     {
         var concurrency = 20;
-        var indexName = "upsert_test";
         var vectorSize = 4;
+        var indexName = "upsert_test" + Guid.NewGuid().ToString("D");
 
         using var target = new PostgresMemory(this.PostgresConfiguration, new FakeEmbeddingGenerator());
 

--- a/tests/FunctionalTests/IndexCreationTests.cs
+++ b/tests/FunctionalTests/IndexCreationTests.cs
@@ -30,5 +30,43 @@ public class IndexCreationTests : BaseTestCase
         // Act - Assert no exception occurs
         await memory.ImportTextAsync("something", index: indexNameWithDashes);
         await memory.ImportTextAsync("something", index: indexNameWithUnderscores);
+
+        // Cleanup
+        await memory.DeleteIndexAsync(indexNameWithDashes);
+        await memory.DeleteIndexAsync(indexNameWithUnderscores);
+    }
+
+    [Theory]
+    [InlineData("postgres")]
+    [InlineData("simple_volatile")]
+    [InlineData("az_ai_search")]
+    public async Task ItListsIndexes(string memoryType)
+    {
+        // Arrange
+        string indexNameWithDashes = "name-with-dashes";
+        string indexNameWithUnderscores = "name_with_underscore";
+        string indexNameWithUnderscoresNormalized = "name-with-underscore";
+
+        var memory = new KernelMemoryBuilder()
+            .WithPostgres(this.PostgresConfiguration)
+            .WithSimpleFileStorage(new SimpleFileStorageConfig { StorageType = FileSystemTypes.Volatile, Directory = "_files" })
+            // .WithOpenAI(this.OpenAIConfiguration)
+            .WithAzureOpenAITextGeneration(this.AzureOpenAITextConfiguration)
+            .WithAzureOpenAITextEmbeddingGeneration(this.AzureOpenAIEmbeddingConfiguration)
+            .Build();
+
+        // Act
+        await memory.ImportTextAsync("something", index: indexNameWithDashes);
+        await memory.ImportTextAsync("something", index: indexNameWithUnderscores);
+        var list = (await memory.ListIndexesAsync()).ToList();
+
+        // Clean up before exceptions can occur
+        await memory.DeleteIndexAsync(indexNameWithDashes);
+        await memory.DeleteIndexAsync(indexNameWithUnderscores);
+
+        // Assert
+        Assert.True(list.Any(x => x.Name == indexNameWithDashes));
+        Assert.False(list.Any(x => x.Name == indexNameWithUnderscores));
+        Assert.True(list.Any(x => x.Name == indexNameWithUnderscoresNormalized));
     }
 }

--- a/tests/TestApplication/appsettings.json
+++ b/tests/TestApplication/appsettings.json
@@ -10,7 +10,7 @@
         "ConnectionString": "Host=localhost;Port=5432;Username=postgres;Password=",
         // Mandatory prefix to add to the name of table managed by KM,
         // e.g. to exclude other tables in the same schema.
-        "TableNamePrefix": "km_",
+        "TableNamePrefix": "km-",
       },
       "AzureOpenAIText": {
         // "ApiKey" or "AzureIdentity"


### PR DESCRIPTION
KM uses the dash "-" symbol as the standard char across different storage connectors, so this change aligns Postgres behavior with KM. This is mostly visible when creating and fetching index names, because "_" is automatically turned into "-", so the index name used in input might differ from the one received in output, e.g. when listing indexes.

Other:
- bump version to 0.3
- auto normalize "_" to "-" also in table name prefix config
- update docs and configs changing "km_" to "km-"
- clean up some test tables left over after running functional tests